### PR TITLE
Add content-type to response headers

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject ring-cljsjs "0.1.0"
+(defproject ring-cljsjs "0.2.0-SNAPSHOT"
   :description "Ring middleware to serve assets from Cljsjs packages"
   :url "https://github.com/deraen/ring-cljsjs"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [ring/ring-core "1.4.0"]]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [ring/ring-core "1.7.1"]]
   :profiles
   {:dev {:dependencies [[cljsjs/react-mdl "1.4.3-0"]
                         [ring/ring-mock "0.2.0"]]}})


### PR DESCRIPTION
This change adds the content-type response header based on the file extension of the resource.
This solves a problem with reverse proxy traefik. Traefik sets the content-type header to "text/plain" if no header is provided by the backend service which causes problems with CSS in the browser.